### PR TITLE
Adds healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ COPY --from=build-env /app /app
 WORKDIR /app
 CMD ["server.js"]
 EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=2s --start-period=5s --retries=2 CMD ["/nodejs/bin/node", "healthcheck.js", "||", "exit", "1"]

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,23 +1,23 @@
-var http = require("http");
+const http = require('http')
 
-var options = {
-  host: "localhost",
-  port: "8080",
-  timeout: 1000,
-};
+const options = {
+  host: 'localhost',
+  port: '8080',
+  timeout: 1000
+}
 
-var request = http.request(options, (res) => {
-  console.log(`STATUS: ${res.statusCode}`);
-  if (res.statusCode == 401) {
-    process.exit(0);
+const request = http.request(options, (res) => {
+  console.log(`STATUS: ${res.statusCode}`)
+  if (res.statusCode === 401) {
+    process.exit(0)
   } else {
-    process.exit(1);
+    process.exit(1)
   }
-});
+})
 
-request.on("error", function (err) {
-  console.log("ERROR");
-  process.exit(1);
-});
+request.on('error', function (err) {
+  console.log(err)
+  process.exit(1)
+})
 
-request.end();
+request.end()

--- a/healthcheck.js
+++ b/healthcheck.js
@@ -1,0 +1,23 @@
+var http = require("http");
+
+var options = {
+  host: "localhost",
+  port: "8080",
+  timeout: 1000,
+};
+
+var request = http.request(options, (res) => {
+  console.log(`STATUS: ${res.statusCode}`);
+  if (res.statusCode == 401) {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
+});
+
+request.on("error", function (err) {
+  console.log("ERROR");
+  process.exit(1);
+});
+
+request.end();


### PR DESCRIPTION
This PR adds a health check to the Dockerfile. It is purely meant to check whether the container has successfully started and is capable of accepting HTTP requests. This allows for zero downtime rolling deploys using Docker Swarm.

More “in depth checking” to make sure the container is actually capable of functioning as a proxy will be done by external monitoring tools.